### PR TITLE
Add monitoring discovery troubleshooting info

### DIFF
--- a/content/troubleshooting_guides/FAQ/monitoringdiscovery.md
+++ b/content/troubleshooting_guides/FAQ/monitoringdiscovery.md
@@ -1,6 +1,33 @@
 ---
-title: Monitoring & Discovery 
+title: Monitoring & Discovery
 geekdocHidden : True
 ---
 
-In Constructions
+## Overview
+
+Typical issues during monitoring and discovery include unreachable devices, incorrect or outdated SNMP/Agent credentials, and blocked network ports. These problems prevent the NetGain server from collecting data or identifying devices on the network.
+
+## Steps to resolve
+
+1. Verify that the device responds to `ping` from the NetGain server.
+2. Confirm SNMP or agent services are running and accessible.
+3. Double‑check community strings or authentication details.
+4. Ensure firewalls allow required ports such as UDP 161 for SNMP.
+5. Rerun the discovery wizard and review logs for errors.
+6. Use `snmpwalk` or similar tools to verify a device responds correctly.
+
+<details>
+<summary>Show discovery flow diagram</summary>
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant D as Discovery Engine
+  participant T as Target Device
+  U->>D: Start discovery
+  D->>T: Probe SNMP/Agent
+  T-->>D: Respond with details
+  D->>U: Display found device
+```
+
+</details>

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 all: hugo push
 
 hugo:
-	hugo
+	hugo --config config_netgain.yaml,config_common.yaml
 
 push:
 	git push


### PR DESCRIPTION
## Summary
- flesh out the Monitoring & Discovery FAQ page
- include additional troubleshooting step
- fix makefile to use config files so `make hugo` works

## Testing
- `make hugo`


------
https://chatgpt.com/codex/tasks/task_b_685e8274881883339da0d180090c63ce